### PR TITLE
Potential Firefox plugin update

### DIFF
--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,0 +1,30 @@
+{
+    "manifest_version": 2,
+    "name": "Imgur Community Extension",
+    "description": "A Firefox extension made by and for the Imgur Community.",
+    "version": "1.1",
+    "icons": { 
+        "128": "icon128.png" 
+	},
+    "permissions": [
+		"storage"
+	],
+	"applications": {
+		"gecko": {
+		  "id": "imgurCE@mozilla.com",
+		  "strict_min_version": "45.0",
+		  "update_url": "https://github.com/kyrofox/iceproject/blob/master/firefox/versionControl.txt"
+		}
+	},
+	"content_scripts": [
+        {
+          "matches": ["*://*.imgur.com/*"],
+          "js": ["jquery-2.2.2.min.js", "icepage.js"],
+		  "css": ["ice.css"],
+		  "run_at": "document_end"
+        }
+    ],
+    "background": {
+		"scripts": ["icebg.js"]
+    }
+}

--- a/firefox/versionControl.txt
+++ b/firefox/versionControl.txt
@@ -1,13 +1,15 @@
 {
   "addons": {
-    "imgurCE": {
+    "Imgur Community Extension": {
       "updates": [
-        { "version": "1.0",
+        { 
+          "version": "1.0",
           "update_link": "https://raw.githubusercontent.com/kyrofox/iceproject/master/versions/ice1.0.xpi" 
-		},
-        { "version": "1.1",
+        },
+        { 
+          "version": "1.1",
           "update_link": "https://raw.githubusercontent.com/kyrofox/iceproject/master/versions/ice1.1.xpi"
-		}
+        }
       ]
     }
   }

--- a/firefox/versionControl.txt
+++ b/firefox/versionControl.txt
@@ -1,0 +1,14 @@
+{
+  "addons": {
+    "imgurCE": {
+      "updates": [
+        { "version": "1.0",
+          "update_link": "https://raw.githubusercontent.com/kyrofox/iceproject/master/versions/ice1.0.xpi" 
+		},
+        { "version": "1.1",
+          "update_link": "https://raw.githubusercontent.com/kyrofox/iceproject/master/versions/ice1.1.xpi"
+		}
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I have made a modified manifest file which works with Firefox (from version 45 and newer, current stable is 46).
This is using the chrome source so there is no need for multiple sources.

For a firefox plugin all that is left is for @kyrofox to make a signed XPI package and it should be able to go on both the Firefox add-on "store", and on Github for future version control.
